### PR TITLE
節約金額一覧を表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'net-smtp', require: false
 
 gem 'chartkick'
 
+gem 'kaminari'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,18 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     loofah (2.17.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -297,6 +309,7 @@ DEPENDENCIES
   factory_bot_rails
   importmap-rails
   jbuilder
+  kaminari
   net-smtp
   pg (~> 1.1)
   puma (>= 5.6.4)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
 
   def show
     @user = User.find(current_user.id)
+    @savings = @user.savings.page(params[:page])
     @savings_top_three = @user.savings.order(money: :desc).limit(3)
   end
 end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -25,5 +25,27 @@
       </tbody>
     </table>
   </div>
-</div>
 
+  <h2 class='p-4 text-xl'>節約額一覧<h2>
+  <div class='p-4'>
+    <table class='table-auto'>
+      <thead>
+        <tr>
+          <th class='px-4 py-2'>ラベル</th>
+          <th class='px-4 py-2'>金額</th>
+          <th class='px-4 py-2'>日付</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @savings.each do |saving| %>
+          <tr>
+            <td class='border px-4 py-2'><%= saving.label %></td>
+            <td class='border px-4 py-2'><%= saving.money %></td>
+            <td class='border px-4 py-2'><%= saving.created_at.strftime('%Y/%m/%d') %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= paginate @savings %>
+  </div>
+</div>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
## 概要

節約金額一覧をページネーション付きで表示する

## やること
- [x] kaminariの導入
- [x] 節約金額一覧の表示
  - [x] ページネーション表示

## やらないこと
- UIを整えること
  - 別PRで他の項目含めて対応する

## 画面
<img width="1313" alt="スクリーンショット 2022-05-03 18 58 24" src="https://user-images.githubusercontent.com/32436625/166435103-f9a2b2d9-b1fb-48f4-a72a-79f320e5f9c7.png">
