### PR TITLE
カテゴリーテーブルの追加

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,8 +1,6 @@
 name: Ruby
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  NewCops: enable
   Exclude:
     - "vendor/**/*" # rubocop config/default.yml
     - "db/**/*"

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'chartkick'
 
 gem 'kaminari'
 
+gem 'active_decorator'
+
 # Use Sass to process CSS
 # gem "sassc-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_decorator (1.4.0)
+      activesupport
     activejob (7.0.2.4)
       activesupport (= 7.0.2.4)
       globalid (>= 0.3.6)
@@ -297,6 +299,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_decorator
   annotate
   bootsnap
   brakeman

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,7 @@ class UsersController < ApplicationController
                         .group('categories.label')
                         .count
                         .map do |k, v|
-                                  k = 'その他' if k.nil?
+      k = 'その他' if k.nil?
                                   { k => v }
     end
     @savings_by_categories = {}.merge(*savings_hash)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     # delegate to decorator
     savings_hash = @user.savings.left_joins(:category)
                         .group('categories.label')
-                                .count
+                        .count
                                 .map do |k,v|
                                   k = 'その他' if k.nil?
                                   { k => v }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
     @savings_top_three = @user.savings.order(money: :desc).limit(3)
     # delegate to decorator
     savings_hash = @user.savings.left_joins(:category)
-                                .group('categories.label')
+                        .group('categories.label')
                                 .count
                                 .map do |k,v|
                                   k = 'その他' if k.nil?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
                         .map do |k,v|
                                   k = 'その他' if k.nil?
                                   { k => v }
-                                end
+    end
     @savings_by_categories = {}.merge(*savings_hash)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     savings_hash = @user.savings.left_joins(:category)
                         .group('categories.label')
                         .count
-                        .map do |k,v|
+                        .map do |k, v|
                                   k = 'その他' if k.nil?
                                   { k => v }
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,5 +5,14 @@ class UsersController < ApplicationController
     @user = User.find(current_user.id)
     @savings = @user.savings.page(params[:page])
     @savings_top_three = @user.savings.order(money: :desc).limit(3)
+    # delegate to decorator
+    savings_hash = @user.savings.left_joins(:category)
+                                .group('categories.label')
+                                .count
+                                .map do |k,v|
+                                  k = 'その他' if k.nil?
+                                  { k => v }
+                                end
+    @savings_by_categories = {}.merge(*savings_hash)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
                         .count
                         .map do |k, v|
       k = 'その他' if k.nil?
-                                  { k => v }
+      { k => v }
     end
     @savings_by_categories = {}.merge(*savings_hash)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,14 +5,5 @@ class UsersController < ApplicationController
     @user = User.find(current_user.id)
     @savings = @user.savings.page(params[:page])
     @savings_top_three = @user.savings.order(money: :desc).limit(3)
-    # delegate to decorator
-    savings_hash = @user.savings.left_joins(:category)
-                        .group('categories.label')
-                        .count
-                        .map do |k, v|
-      k = 'その他' if k.nil?
-      { k => v }
-    end
-    @savings_by_categories = {}.merge(*savings_hash)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
     savings_hash = @user.savings.left_joins(:category)
                         .group('categories.label')
                         .count
-                                .map do |k,v|
+                        .map do |k,v|
                                   k = 'その他' if k.nil?
                                   { k => v }
                                 end

--- a/app/decorators/user_decorator.rb
+++ b/app/decorators/user_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module UserDecorator
+  def savings_by_categories
+    savings_hash = savings.left_joins(:category)
+                          .group('categories.label')
+                          .count
+                          .map do |k, v|
+      k = 'その他' if k.nil?
+      { k => v }
+    end
+
+    {}.merge(*savings_hash)
+  end
+end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  label      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Category < ApplicationRecord
   has_many :savings
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :savings
+end

--- a/app/models/saving.rb
+++ b/app/models/saving.rb
@@ -13,7 +13,7 @@
 
 class Saving < ApplicationRecord
   belongs_to :user
-  belongs_to :category
+  belongs_to :category, optional: true
 
   class << self
     # TODO : 期間ごと集計を可能にする

--- a/app/models/saving.rb
+++ b/app/models/saving.rb
@@ -12,6 +12,7 @@
 
 class Saving < ApplicationRecord
   belongs_to :user
+  belongs_to :category
 
   class << self
     # TODO : 期間ごと集計を可能にする

--- a/app/models/saving.rb
+++ b/app/models/saving.rb
@@ -2,12 +2,13 @@
 #
 # Table name: savings
 #
-#  id         :integer          not null, primary key
-#  label      :string           default(""), not null
-#  money      :integer          default("0"), not null
-#  user_id    :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  label       :string           default(""), not null
+#  money       :integer          default(0), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint
 #
 
 class Saving < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  name                   :string           not null
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,12 +7,20 @@
   </div>
 
   <div class='shadow-xl rounded-lg overflow-hidden mb-6'>
+    <h2 class='py-3 px-5 bg-gray-100'>カテゴリ別節約</h2>
+    <div class='p-4'>
+      <%= pie_chart @savings_by_categories %>
+    </div>
+  </div>
+
+  <div class='shadow-xl rounded-lg overflow-hidden mb-6'>
     <h2 class='py-3 px-5 bg-gray-100'>節約額トップ3<h2>
     <div class='p-4'>
       <table class='table-auto w-full'>
         <thead>
           <tr>
             <th class='px-4 py-2'>ラベル</th>
+            <th class='px-4 py-2'>カテゴリ</th>
             <th class='px-4 py-2'>金額</th>
             <th class='px-4 py-2'>日付</th>
           </tr>
@@ -21,6 +29,7 @@
           <% @savings_top_three.each do |saving| %>
             <tr>
               <td class='border px-4 py-2'><%= saving.label %></td>
+              <td class='border px-4 py-2'><%= saving.category&.label %></td>
               <td class='border px-4 py-2'><%= saving.money %></td>
               <td class='border px-4 py-2'><%= saving.created_at.strftime('%Y/%m/%d') %></td>
             </tr>
@@ -37,6 +46,7 @@
         <thead>
           <tr>
             <th class='px-4 py-2'>ラベル</th>
+            <th class='px-4 py-2'>カテゴリ</th>
             <th class='px-4 py-2'>金額</th>
             <th class='px-4 py-2'>日付</th>
           </tr>
@@ -45,6 +55,7 @@
           <% @savings.each do |saving| %>
             <tr>
               <td class='border px-4 py-2'><%= saving.label %></td>
+              <td class='border px-4 py-2'><%= saving.category&.label %></td>
               <td class='border px-4 py-2'><%= saving.money %></td>
               <td class='border px-4 py-2'><%= saving.created_at.strftime('%Y/%m/%d') %></td>
             </tr>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,7 +9,7 @@
   <div class='shadow-xl rounded-lg overflow-hidden mb-6'>
     <h2 class='py-3 px-5 bg-gray-100'>カテゴリ別節約</h2>
     <div class='p-4'>
-      <%= pie_chart @savings_by_categories %>
+      <%= pie_chart @user.savings_by_categories %>
     </div>
   </div>
 

--- a/db/migrate/20220507093243_create_categories.rb
+++ b/db/migrate/20220507093243_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[7.0]
+  def change
+    create_table :categories do |t|
+      t.string :label, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20220507093328_add_category_id_to_savings.rb
+++ b/db/migrate/20220507093328_add_category_id_to_savings.rb
@@ -1,0 +1,5 @@
+class AddCategoryIdToSavings < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :savings, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,17 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_04_081233) do
-
+ActiveRecord::Schema[7.0].define(version: 2022_05_07_093328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "categories", force: :cascade do |t|
+    t.string "label", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "savings", force: :cascade do |t|
     t.string "label", default: "", null: false
     t.integer "money", default: 0, null: false
     t.bigint "user_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "category_id"
+    t.index ["category_id"], name: "index_savings_on_category_id"
     t.index ["user_id"], name: "index_savings_on_user_id"
   end
 
@@ -29,10 +36,10 @@ ActiveRecord::Schema.define(version: 2022_01_04_081233) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: 6
-    t.datetime "remember_created_at", precision: 6
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe UserDecorator, type: :decorator do
+  let(:user) { create(:user) }
+  before { ActiveDecorator::Decorator.instance.decorate user }
+  let!(:savings) { create_list(:saving, 2, :with_category, user: user) }
+  subject { user.savings_by_categories }
+
+  describe '#savings_by_categories' do
+    context 'categories#labelがnilが存在する場合' do
+      before do
+        savings.last.update(category_id: nil)
+      end
+
+      it 'return hash key "その他" instead of nil' do
+        expect(subject).to eq ({'category_1'=>1, 'その他'=>1})
+      end
+    end
+
+    context 'categories#labelがnilが存在しない場合' do
+      it 'return hash key as they are' do
+        expect(subject).to eq ({'category_3'=>1, 'category_4'=>1})
+      end
+    end
+  end
+end

--- a/spec/decorators/user_decorator_spec.rb
+++ b/spec/decorators/user_decorator_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe UserDecorator, type: :decorator do
   let(:user) { create(:user) }
   before { ActiveDecorator::Decorator.instance.decorate user }
-  let!(:savings) { create_list(:saving, 2, :with_category, user: user) }
+  let!(:savings) { create_list(:saving, 2, :with_category, user:) }
   subject { user.savings_by_categories }
 
   describe '#savings_by_categories' do
@@ -13,13 +13,13 @@ describe UserDecorator, type: :decorator do
       end
 
       it 'return hash key "その他" instead of nil' do
-        expect(subject).to eq ({'category_1'=>1, 'その他'=>1})
+        expect(subject).to eq({ 'category_1' => 1, 'その他' => 1 })
       end
     end
 
     context 'categories#labelがnilが存在しない場合' do
       it 'return hash key as they are' do
-        expect(subject).to eq ({'category_3'=>1, 'category_4'=>1})
+        expect(subject).to eq({ 'category_3' => 1, 'category_4' => 1 })
       end
     end
   end

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  label      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+FactoryBot.define do
+  factory :category do
+    sequence(:label) { |n| "category_#{n}" }
+  end
+end

--- a/spec/factories/savings.rb
+++ b/spec/factories/savings.rb
@@ -14,5 +14,9 @@ FactoryBot.define do
   factory :saving do
     sequence(:label) { |n| "label_#{n}" }
     money { 1000 }
+
+    trait 'with_category' do
+      association :category
+    end
   end
 end

--- a/spec/factories/savings.rb
+++ b/spec/factories/savings.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: savings
+#
+#  id          :bigint           not null, primary key
+#  label       :string           default(""), not null
+#  money       :integer          default(0), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint
+#
 FactoryBot.define do
   factory :saving do
     sequence(:label) { |n| "label_#{n}" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  name                   :string           not null
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  reset_password_token   :string
+#  reset_password_sent_at :datetime
+#  remember_created_at    :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
 FactoryBot.define do
   factory :user do
     sequence(:name)     { |n| "user_#{n}" }

--- a/spec/models/saving_spec.rb
+++ b/spec/models/saving_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: savings
+#
+#  id          :bigint           not null, primary key
+#  label       :string           default(""), not null
+#  money       :integer          default(0), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint
+#
 require 'rails_helper'
 
 RSpec.describe Saving, type: :model do

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  label: MyString
+
+two:
+  label: MyString

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,4 +1,12 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  label      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 
 one:
   label: MyString

--- a/test/fixtures/savings.yml
+++ b/test/fixtures/savings.yml
@@ -2,12 +2,13 @@
 #
 # Table name: savings
 #
-#  id         :integer          not null, primary key
-#  label      :string           default(""), not null
-#  money      :integer          default("0"), not null
-#  user_id    :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  label       :string           default(""), not null
+#  money       :integer          default(0), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint
 #
 
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  name                   :string           not null
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -7,7 +7,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
-require "test_helper"
+require 'test_helper'
 
 class CategoryTest < ActiveSupport::TestCase
   # test "the truth" do

--- a/test/models/category_test.rb
+++ b/test/models/category_test.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: categories
+#
+#  id         :bigint           not null, primary key
+#  label      :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 require "test_helper"
 
 class CategoryTest < ActiveSupport::TestCase

--- a/test/models/saving_test.rb
+++ b/test/models/saving_test.rb
@@ -2,12 +2,13 @@
 #
 # Table name: savings
 #
-#  id         :integer          not null, primary key
-#  label      :string           default(""), not null
-#  money      :integer          default("0"), not null
-#  user_id    :integer          not null
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id          :bigint           not null, primary key
+#  label       :string           default(""), not null
+#  money       :integer          default(0), not null
+#  user_id     :bigint           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :bigint
 #
 
 require 'test_helper'

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -2,7 +2,7 @@
 #
 # Table name: users
 #
-#  id                     :integer          not null, primary key
+#  id                     :bigint           not null, primary key
 #  name                   :string           not null
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null


### PR DESCRIPTION
## 概要

節約項目に「食料品」などのカテゴリを追加するためにテーブルを追加

## ER図

<img width="644" alt="スクリーンショット 2022-05-09 15 57 40" src="https://user-images.githubusercontent.com/32436625/167356609-2bc27dc3-2ea5-4e10-99c7-7f1b5628a34f.png">

categoryはsavingsに紐づかないこともある。
category無しのsavingsを登録できるようにするため

## やること
- [x] カテゴリーテーブル追加
- [x] リレーション定義
- [x] カテゴリー名表示
- [x] カテゴリーごとの節約円グラフ表示

## やらないこと

## キャプチャ
<img width="1232" alt="スクリーンショット 2022-05-09 15 50 23" src="https://user-images.githubusercontent.com/32436625/167355583-0d2e0664-e27a-4fb8-9ea2-9431e9d222b7.png">
