### PR TITLE
mailcatcher導入

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,11 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
+
+  config.action_mailer.default_url_options = { :host => 'example.com' }
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address: 'mailcatcher',
+    port: 1025
+  }
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,11 @@ services:
     image: redis
     volumes:
       - redis_data:/data
+  mailcatcher:
+    image: schickling/mailcatcher
+    ports:
+      - "1080:1080"
+      - "1025:1025"
 
 volumes:
   pg_data:


### PR DESCRIPTION
## 概要

パスワードリセットの動作確認用に [mailcatcher](https://hub.docker.com/r/schickling/mailcatcher) を導入する

## やること
- [x] [mailcatcher](https://hub.docker.com/r/schickling/mailcatcher) のコンテナ導入
- [x] config/development.rbにローカルでmail送信できる設定を追加

## やらないこと

